### PR TITLE
Clean up chmod/chown examples:

### DIFF
--- a/_posts/detail/2012-07-01-linux.html
+++ b/_posts/detail/2012-07-01-linux.html
@@ -373,12 +373,12 @@ title:     Linux Command Line Cheat Sheet
                 <li class="tip">write (w)</li>
                 <li>1</li>
                 <li class="tip">execute (x)</li>
-                <li>chmod 775 file</li>
-                <li class="tip">Change mode of file to 775</li>
-                <li>chmod -R 600 folder</li>
-                <li class="tip">Recurs-ively chmod folder to 600</li>
-                <li>chown user-:g-roup file</li>
-                <li class="tip">Change file owner to user and group to group</li>
+                <li>chmod 644 file</li>
+                <li class="tip">Change mode of file to <span style="white-space: nowrap">rw-r--r--</span></li>
+                <li>chmod -R 750 folder</li>
+                <li class="tip">Recursively chmod folder and contents to <span style="white-space: nowrap">rwxr-x---</span></li>
+                <li>chown usr:grp file</li>
+                <li class="tip">Change file owner to usr, and group to grp</li>
             </ul>
         </div>
     </div>


### PR DESCRIPTION
* For numeric chmod examples, show the symbolic result rather than just repeating the number.

* Suggesting to chmod a folder to 600 is a bad idea, so do the folder 750 and the file 644.

* Get rid of stray hyphens.

* Make chown example clearer by using 'usr' and 'grp' in the command instead of 'user' and 'group', thus avoiding phrases like "group to group".