### PR TITLE
Update link to Fortran reference card

### DIFF
--- a/_posts/f/2012-07-01-fortran.html
+++ b/_posts/f/2012-07-01-fortran.html
@@ -14,8 +14,8 @@ title:     Fortran Cheat Sheet
         <div class="board-card">
             <h3 class="board-card-title">Download</h3>
             <ul>
-                <li><a href="http://users.physik.fu-berlin.de/~goerz/refcards/fortran90_refcard.pdf">Fortran 90 Reference Card [.pdf, odt]</a></li>
-                <li><a href="/static/cs/fortran90_refcard.pdf">Fortran 90 Reference Card [backup]</a></li>
+                <li><a href="http://michaelgoerz.net/refcards/fortran_refcard_a4.pdf">Modern Fortran Reference Card [.pdf]</a></li>
+                <li><a href="/static/cs/fortran90_refcard.pdf">Fortran 90 Reference Card</a></li>
             </ul>
         </div>
         <div class="board-card">


### PR DESCRIPTION
Updated the link for my Fortran reference card. The new "Modern Fortran Reference Card" is an update to my "Fortran 90 Reference Card" from a few years ago. The latter is no longer available, but I'll leave it up to you whether you want to keep the mirrored backup copy.