### PR TITLE
typo/missing-s-on-miscellaneous

### DIFF
--- a/_posts/detail/2012-07-01-css.html
+++ b/_posts/detail/2012-07-01-css.html
@@ -439,7 +439,7 @@ title:     CSS Cheat Sheet
     </div>
 
     <div class="board">
-        <h2 class="board-title">Miscellaneou</h2>
+        <h2 class="board-title">Miscellaneous</h2>
         <div class="board-card">
             <h3 class="board-card-title">Print</h3>
             <ul>


### PR DESCRIPTION
typo: missing s on Miscellaneous