### PR TITLE
update links to point to current version

### DIFF
--- a/_posts/detail/2012-07-01-ruby.html
+++ b/_posts/detail/2012-07-01-ruby.html
@@ -31,98 +31,98 @@ title:     Ruby Cheat Sheet
         <h2 class="board-title">Array</h2>
         <div class="board-card">
             <ul>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-c-5B-5D">::[]</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-c-new">::new</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-c-try_convert">::try_convert</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-26">#&amp;</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-2A">#*</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-2B">#+</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-2D">#-</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-3C-3C">#&lt;&lt;</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-3C-3D-3E">#&lt;=&gt;</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-3D-3D">#==</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-5B-5D">#[]</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-5B-5D-3D">#[]=</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-assoc">#assoc</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-at">#at</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-clear">#clear</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-collect">#collect</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-collect-21">#collect!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-combination">#combination</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-compact">#compact</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-compact-21">#compact!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-concat">#concat</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-count">#count</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-cycle">#cycle</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-delete">#delete</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-delete_at">#delete_at</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-delete_if">#delete_if</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-drop">#drop</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-drop_while">#drop_while</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-each">#each</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-each_index">#each_index</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-empty-3F">#empty?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-eql-3F">#eql?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-fetch">#fetch</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-fill">#fill</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-find_index">#find_index</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-first">#first</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-flatten">#flatten</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-flatten-21">#flatten!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-frozen-3F">#frozen?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-hash">#hash</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-include-3F">#include?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-index">#index</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-initialize_copy">#initialize_copy</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-insert">#insert</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-inspect">#inspect</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-join">#join</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-keep_if">#keep_if</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-last">#last</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-length">#length</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-map">#map</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-map-21">#map!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-pack">#pack</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-permutation">#permutation</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-pop">#pop</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-product">#product</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-push">#push</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-rassoc">#rassoc</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-reject">#reject</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-reject-21">#reject!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-repeated_combination">#repeated_combination</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-repeated_permutation">#repeated_permutation</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-replace">#replace</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-reverse">#reverse</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-reverse-21">#reverse!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-reverse_each">#reverse_each</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-rindex">#rindex</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-rotate">#rotate</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-rotate-21">#rotate!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-sample">#sample</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-select">#select</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-select-21">#select!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-shift">#shift</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-shuffle">#shuffle</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-shuffle-21">#shuffle!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-size">#size</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-slice">#slice</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-slice-21">#slice!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-sort">#sort</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-sort-21">#sort!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-sort_by-21">#sort_by!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-take">#take</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-take_while">#take_while</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-to_a">#to_a</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-to_ary">#to_ary</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-to_s">#to_s</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-transpose">#transpose</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-uniq">#uniq</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-uniq-21">#uniq!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-unshift">#unshift</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-values_at">#values_at</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-zip">#zip</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-7C">#|</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-c-5B-5D">::[]</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-c-new">::new</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-c-try_convert">::try_convert</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-26">#&amp;</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-2A">#*</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-2B">#+</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-2D">#-</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-3C-3C">#&lt;&lt;</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-3C-3D-3E">#&lt;=&gt;</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-3D-3D">#==</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-5B-5D">#[]</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-5B-5D-3D">#[]=</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-assoc">#assoc</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-at">#at</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-clear">#clear</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-collect">#collect</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-collect-21">#collect!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-combination">#combination</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-compact">#compact</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-compact-21">#compact!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-concat">#concat</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-count">#count</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-cycle">#cycle</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-delete">#delete</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-delete_at">#delete_at</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-delete_if">#delete_if</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-drop">#drop</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-drop_while">#drop_while</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-each">#each</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-each_index">#each_index</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-empty-3F">#empty?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-eql-3F">#eql?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-fetch">#fetch</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-fill">#fill</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-find_index">#find_index</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-first">#first</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-flatten">#flatten</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-flatten-21">#flatten!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-frozen-3F">#frozen?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-hash">#hash</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-include-3F">#include?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-index">#index</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-initialize_copy">#initialize_copy</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-insert">#insert</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-inspect">#inspect</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-join">#join</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-keep_if">#keep_if</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-last">#last</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-length">#length</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-map">#map</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-map-21">#map!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-pack">#pack</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-permutation">#permutation</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-pop">#pop</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-product">#product</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-push">#push</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-rassoc">#rassoc</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-reject">#reject</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-reject-21">#reject!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-repeated_combination">#repeated_combination</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-repeated_permutation">#repeated_permutation</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-replace">#replace</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-reverse">#reverse</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-reverse-21">#reverse!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-reverse_each">#reverse_each</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-rindex">#rindex</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-rotate">#rotate</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-rotate-21">#rotate!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-sample">#sample</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-select">#select</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-select-21">#select!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-shift">#shift</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-shuffle">#shuffle</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-shuffle-21">#shuffle!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-size">#size</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-slice">#slice</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-slice-21">#slice!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-sort">#sort</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-sort-21">#sort!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-sort_by-21">#sort_by!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-take">#take</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-take_while">#take_while</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-to_a">#to_a</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-to_ary">#to_ary</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-to_s">#to_s</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-transpose">#transpose</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-uniq">#uniq</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-uniq-21">#uniq!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-unshift">#unshift</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-values_at">#values_at</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-zip">#zip</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Array.html#method-i-7C">#|</a></li>
             </ul>
         </div>
     </div>
@@ -131,76 +131,76 @@ title:     Ruby Cheat Sheet
         <h2 class="board-title">File</h2>
         <div class="board-card">
             <ul>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-absolute_path">::absolute_path</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-atime">::atime</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-basename">::basename</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-blockdev-3F">::blockdev?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-chardev-3F">::chardev?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-chmod">::chmod</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-chown">::chown</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-ctime">::ctime</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-delete">::delete</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-directory-3F">::directory?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-dirname">::dirname</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-executable-3F">::executable?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-executable_real-3F">::executable_real?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-exist-3F">::exist?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-exists-3F">::exists?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-expand_path">::expand_path</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-extname">::extname</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-file-3F">::file?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-fnmatch">::fnmatch</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-fnmatch-3F">::fnmatch?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-ftype">::ftype</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-grpowned-3F">::grpowned?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-identical-3F">::identical?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-join">::join</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-lchmod">::lchmod</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-lchown">::lchown</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-link">::link</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-lstat">::lstat</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-mtime">::mtime</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-new">::new</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-open">::open</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-owned-3F">::owned?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-path">::path</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-pipe-3F">::pipe?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-readable-3F">::readable?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-readable_real-3F">::readable_real?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-readlink">::readlink</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-realdirpath">::realdirpath</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-realpath">::realpath</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-rename">::rename</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-setgid-3F">::setgid?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-setuid-3F">::setuid?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-size">::size</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-size-3F">::size?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-socket-3F">::socket?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-split">::split</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-stat">::stat</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-sticky-3F">::sticky?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-symlink">::symlink</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-symlink-3F">::symlink?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-truncate">::truncate</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-umask">::umask</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-unlink">::unlink</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-utime">::utime</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-world_readable-3F">::world_readable?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-world_writable-3F">::world_writable?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-writable-3F">::writable?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-writable_real-3F">::writable_real?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-c-zero-3F">::zero?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-i-atime">#atime</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-i-chmod">#chmod</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-i-chown">#chown</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-i-ctime">#ctime</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-i-flock">#flock</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-i-lstat">#lstat</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-i-mtime">#mtime</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-i-path">#path</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-i-size">#size</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-i-to_path">#to_path</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/File.html#method-i-truncate">#truncate</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-absolute_path">::absolute_path</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-atime">::atime</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-basename">::basename</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-blockdev-3F">::blockdev?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-chardev-3F">::chardev?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-chmod">::chmod</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-chown">::chown</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-ctime">::ctime</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-delete">::delete</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-directory-3F">::directory?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-dirname">::dirname</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-executable-3F">::executable?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-executable_real-3F">::executable_real?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-exist-3F">::exist?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-exists-3F">::exists?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-expand_path">::expand_path</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-extname">::extname</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-file-3F">::file?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-fnmatch">::fnmatch</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-fnmatch-3F">::fnmatch?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-ftype">::ftype</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-grpowned-3F">::grpowned?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-identical-3F">::identical?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-join">::join</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-lchmod">::lchmod</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-lchown">::lchown</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-link">::link</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-lstat">::lstat</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-mtime">::mtime</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-new">::new</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-open">::open</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-owned-3F">::owned?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-path">::path</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-pipe-3F">::pipe?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-readable-3F">::readable?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-readable_real-3F">::readable_real?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-readlink">::readlink</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-realdirpath">::realdirpath</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-realpath">::realpath</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-rename">::rename</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-setgid-3F">::setgid?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-setuid-3F">::setuid?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-size">::size</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-size-3F">::size?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-socket-3F">::socket?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-split">::split</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-stat">::stat</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-sticky-3F">::sticky?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-symlink">::symlink</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-symlink-3F">::symlink?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-truncate">::truncate</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-umask">::umask</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-unlink">::unlink</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-utime">::utime</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-world_readable-3F">::world_readable?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-world_writable-3F">::world_writable?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-writable-3F">::writable?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-writable_real-3F">::writable_real?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-c-zero-3F">::zero?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-i-atime">#atime</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-i-chmod">#chmod</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-i-chown">#chown</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-i-ctime">#ctime</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-i-flock">#flock</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-i-lstat">#lstat</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-i-mtime">#mtime</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-i-path">#path</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-i-size">#size</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-i-to_path">#to_path</a></li>
+                <li><a href="http://www.ruby-doc.org/core/File.html#method-i-truncate">#truncate</a></li>
             </ul>
         </div>
     </div>
@@ -209,118 +209,118 @@ title:     Ruby Cheat Sheet
         <h2 class="board-title">String</h2>
         <div class="board-card">
             <ul>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-c-new">::new</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-c-try_convert">::try_convert</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-25">#%</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-2A">#*</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-2B">#+</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-3C-3C">#&lt;&lt;</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-3C-3D-3E">#&lt;=&gt;</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-3D-3D">#==</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-3D-3D-3D">#===</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-3D-7E">#=~</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-5B-5D">#[]</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-5B-5D-3D">#[]=</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-ascii_only-3F">#ascii_only?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-bytes">#bytes</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-bytesize">#bytesize</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-byteslice">#byteslice</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-capitalize">#capitalize</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-capitalize-21">#capitalize!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-casecmp">#casecmp</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-center">#center</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-chars">#chars</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-chomp">#chomp</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-chomp-21">#chomp!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-chop">#chop</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-chop-21">#chop!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-chr">#chr</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-clear">#clear</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-codepoints">#codepoints</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-concat">#concat</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-count">#count</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-crypt">#crypt</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-delete">#delete</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-delete-21">#delete!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-downcase">#downcase</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-downcase-21">#downcase!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-dump">#dump</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-each_byte">#each_byte</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-each_char">#each_char</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-each_codepoint">#each_codepoint</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-each_line">#each_line</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-empty-3F">#empty?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-encode">#encode</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-encode-21">#encode!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-encoding">#encoding</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-end_with-3F">#end_with?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-eql-3F">#eql?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-force_encoding">#force_encoding</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-getbyte">#getbyte</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-gsub">#gsub</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-gsub-21">#gsub!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-hash">#hash</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-hex">#hex</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-include-3F">#include?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-index">#index</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-initialize_copy">#initialize_copy</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-insert">#insert</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-inspect">#inspect</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-intern">#intern</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-length">#length</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-lines">#lines</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-ljust">#ljust</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-lstrip">#lstrip</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-lstrip-21">#lstrip!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-match">#match</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-next">#next</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-next-21">#next!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-oct">#oct</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-ord">#ord</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-partition">#partition</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-prepend">#prepend</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-replace">#replace</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-reverse">#reverse</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-reverse-21">#reverse!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-rindex">#rindex</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-rjust">#rjust</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-rpartition">#rpartition</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-rstrip">#rstrip</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-rstrip-21">#rstrip!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-scan">#scan</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-setbyte">#setbyte</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-size">#size</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-slice">#slice</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-slice-21">#slice!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-split">#split</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-squeeze">#squeeze</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-squeeze-21">#squeeze!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-start_with-3F">#start_with?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-strip">#strip</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-strip-21">#strip!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-sub">#sub</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-sub-21">#sub!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-succ">#succ</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-succ-21">#succ!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-sum">#sum</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-swapcase">#swapcase</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-swapcase-21">#swapcase!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-to_c">#to_c</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-to_f">#to_f</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-to_i">#to_i</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-to_r">#to_r</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-to_s">#to_s</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-to_str">#to_str</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-to_sym">#to_sym</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-tr">#tr</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-tr-21">#tr!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-tr_s">#tr_s</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-tr_s-21">#tr_s!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-unpack">#unpack</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-upcase">#upcase</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-upcase-21">#upcase!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-upto">#upto</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/String.html#method-i-valid_encoding-3F">#valid_encoding?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-c-new">::new</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-c-try_convert">::try_convert</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-25">#%</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-2A">#*</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-2B">#+</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-3C-3C">#&lt;&lt;</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-3C-3D-3E">#&lt;=&gt;</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-3D-3D">#==</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-3D-3D-3D">#===</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-3D-7E">#=~</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-5B-5D">#[]</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-5B-5D-3D">#[]=</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-ascii_only-3F">#ascii_only?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-bytes">#bytes</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-bytesize">#bytesize</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-byteslice">#byteslice</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-capitalize">#capitalize</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-capitalize-21">#capitalize!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-casecmp">#casecmp</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-center">#center</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-chars">#chars</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-chomp">#chomp</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-chomp-21">#chomp!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-chop">#chop</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-chop-21">#chop!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-chr">#chr</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-clear">#clear</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-codepoints">#codepoints</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-concat">#concat</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-count">#count</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-crypt">#crypt</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-delete">#delete</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-delete-21">#delete!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-downcase">#downcase</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-downcase-21">#downcase!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-dump">#dump</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-each_byte">#each_byte</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-each_char">#each_char</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-each_codepoint">#each_codepoint</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-each_line">#each_line</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-empty-3F">#empty?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-encode">#encode</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-encode-21">#encode!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-encoding">#encoding</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-end_with-3F">#end_with?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-eql-3F">#eql?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-force_encoding">#force_encoding</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-getbyte">#getbyte</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-gsub">#gsub</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-gsub-21">#gsub!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-hash">#hash</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-hex">#hex</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-include-3F">#include?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-index">#index</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-initialize_copy">#initialize_copy</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-insert">#insert</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-inspect">#inspect</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-intern">#intern</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-length">#length</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-lines">#lines</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-ljust">#ljust</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-lstrip">#lstrip</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-lstrip-21">#lstrip!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-match">#match</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-next">#next</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-next-21">#next!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-oct">#oct</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-ord">#ord</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-partition">#partition</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-prepend">#prepend</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-replace">#replace</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-reverse">#reverse</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-reverse-21">#reverse!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-rindex">#rindex</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-rjust">#rjust</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-rpartition">#rpartition</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-rstrip">#rstrip</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-rstrip-21">#rstrip!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-scan">#scan</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-setbyte">#setbyte</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-size">#size</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-slice">#slice</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-slice-21">#slice!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-split">#split</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-squeeze">#squeeze</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-squeeze-21">#squeeze!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-start_with-3F">#start_with?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-strip">#strip</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-strip-21">#strip!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-sub">#sub</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-sub-21">#sub!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-succ">#succ</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-succ-21">#succ!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-sum">#sum</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-swapcase">#swapcase</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-swapcase-21">#swapcase!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-to_c">#to_c</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-to_f">#to_f</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-to_i">#to_i</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-to_r">#to_r</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-to_s">#to_s</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-to_str">#to_str</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-to_sym">#to_sym</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-tr">#tr</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-tr-21">#tr!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-tr_s">#tr_s</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-tr_s-21">#tr_s!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-unpack">#unpack</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-upcase">#upcase</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-upcase-21">#upcase!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-upto">#upto</a></li>
+                <li><a href="http://www.ruby-doc.org/core/String.html#method-i-valid_encoding-3F">#valid_encoding?</a></li>
             </ul>
         </div>
     </div>
@@ -329,32 +329,32 @@ title:     Ruby Cheat Sheet
         <h2 class="board-title">Math</h2>
         <div class="board-card">
             <ul>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Math.html#method-c-acos">::acos</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Math.html#method-c-acosh">::acosh</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Math.html#method-c-asin">::asin</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Math.html#method-c-asinh">::asinh</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Math.html#method-c-atan">::atan</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Math.html#method-c-atan2">::atan2</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Math.html#method-c-atanh">::atanh</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Math.html#method-c-cbrt">::cbrt</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Math.html#method-c-cos">::cos</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Math.html#method-c-cosh">::cosh</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Math.html#method-c-erf">::erf</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Math.html#method-c-erfc">::erfc</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Math.html#method-c-exp">::exp</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Math.html#method-c-frexp">::frexp</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Math.html#method-c-gamma">::gamma</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Math.html#method-c-hypot">::hypot</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Math.html#method-c-ldexp">::ldexp</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Math.html#method-c-lgamma">::lgamma</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Math.html#method-c-log">::log</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Math.html#method-c-log10">::log10</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Math.html#method-c-log2">::log2</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Math.html#method-c-sin">::sin</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Math.html#method-c-sinh">::sinh</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Math.html#method-c-sqrt">::sqrt</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Math.html#method-c-tan">::tan</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Math.html#method-c-tanh">::tanh</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Math.html#method-c-acos">::acos</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Math.html#method-c-acosh">::acosh</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Math.html#method-c-asin">::asin</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Math.html#method-c-asinh">::asinh</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Math.html#method-c-atan">::atan</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Math.html#method-c-atan2">::atan2</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Math.html#method-c-atanh">::atanh</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Math.html#method-c-cbrt">::cbrt</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Math.html#method-c-cos">::cos</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Math.html#method-c-cosh">::cosh</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Math.html#method-c-erf">::erf</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Math.html#method-c-erfc">::erfc</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Math.html#method-c-exp">::exp</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Math.html#method-c-frexp">::frexp</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Math.html#method-c-gamma">::gamma</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Math.html#method-c-hypot">::hypot</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Math.html#method-c-ldexp">::ldexp</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Math.html#method-c-lgamma">::lgamma</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Math.html#method-c-log">::log</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Math.html#method-c-log10">::log10</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Math.html#method-c-log2">::log2</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Math.html#method-c-sin">::sin</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Math.html#method-c-sinh">::sinh</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Math.html#method-c-sqrt">::sqrt</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Math.html#method-c-tan">::tan</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Math.html#method-c-tanh">::tanh</a></li>
             </ul>
         </div>
     </div>
@@ -363,30 +363,30 @@ title:     Ruby Cheat Sheet
         <h2 class="board-title">Integer</h2>
         <div class="board-card">
             <ul>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Integer.html#method-i-ceil">#ceil</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Integer.html#method-i-chr">#chr</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Integer.html#method-i-denominator">#denominator</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Integer.html#method-i-downto">#downto</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Integer.html#method-i-even-3F">#even?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Integer.html#method-i-floor">#floor</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Integer.html#method-i-gcd">#gcd</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Integer.html#method-i-gcdlcm">#gcdlcm</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Integer.html#method-i-integer-3F">#integer?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Integer.html#method-i-lcm">#lcm</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Integer.html#method-i-next">#next</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Integer.html#method-i-numerator">#numerator</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Integer.html#method-i-odd-3F">#odd?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Integer.html#method-i-ord">#ord</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Integer.html#method-i-pred">#pred</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Integer.html#method-i-rationalize">#rationalize</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Integer.html#method-i-round">#round</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Integer.html#method-i-succ">#succ</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Integer.html#method-i-times">#times</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Integer.html#method-i-to_i">#to_i</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Integer.html#method-i-to_int">#to_int</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Integer.html#method-i-to_r">#to_r</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Integer.html#method-i-truncate">#truncate</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Integer.html#method-i-upto">#upto</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Integer.html#method-i-ceil">#ceil</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Integer.html#method-i-chr">#chr</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Integer.html#method-i-denominator">#denominator</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Integer.html#method-i-downto">#downto</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Integer.html#method-i-even-3F">#even?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Integer.html#method-i-floor">#floor</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Integer.html#method-i-gcd">#gcd</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Integer.html#method-i-gcdlcm">#gcdlcm</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Integer.html#method-i-integer-3F">#integer?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Integer.html#method-i-lcm">#lcm</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Integer.html#method-i-next">#next</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Integer.html#method-i-numerator">#numerator</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Integer.html#method-i-odd-3F">#odd?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Integer.html#method-i-ord">#ord</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Integer.html#method-i-pred">#pred</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Integer.html#method-i-rationalize">#rationalize</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Integer.html#method-i-round">#round</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Integer.html#method-i-succ">#succ</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Integer.html#method-i-times">#times</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Integer.html#method-i-to_i">#to_i</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Integer.html#method-i-to_int">#to_int</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Integer.html#method-i-to_r">#to_r</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Integer.html#method-i-truncate">#truncate</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Integer.html#method-i-upto">#upto</a></li>
             </ul>
         </div>
     </div>
@@ -395,47 +395,47 @@ title:     Ruby Cheat Sheet
         <h2 class="board-title">Numeric</h2>
         <div class="board-card">
             <ul>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-25">#%</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-2B-40">#+@</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-2D-40">#-@</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-3C-3D-3E">#&lt;=&gt;</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-abs">#abs</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-abs2">#abs2</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-angle">#angle</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-arg">#arg</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-ceil">#ceil</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-coerce">#coerce</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-conj">#conj</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-conjugate">#conjugate</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-denominator">#denominator</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-div">#div</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-divmod">#divmod</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-eql-3F">#eql?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-fdiv">#fdiv</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-floor">#floor</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-i">#i</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-imag">#imag</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-imaginary">#imaginary</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-integer-3F">#integer?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-magnitude">#magnitude</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-modulo">#modulo</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-nonzero-3F">#nonzero?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-numerator">#numerator</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-phase">#phase</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-polar">#polar</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-quo">#quo</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-real">#real</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-real-3F">#real?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-rect">#rect</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-rectangular">#rectangular</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-remainder">#remainder</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-round">#round</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-singleton_method_added">#singleton_method_added</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-step">#step</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-to_c">#to_c</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-to_int">#to_int</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-truncate">#truncate</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Numeric.html#method-i-zero-3F">#zero?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-25">#%</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-2B-40">#+@</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-2D-40">#-@</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-3C-3D-3E">#&lt;=&gt;</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-abs">#abs</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-abs2">#abs2</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-angle">#angle</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-arg">#arg</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-ceil">#ceil</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-coerce">#coerce</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-conj">#conj</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-conjugate">#conjugate</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-denominator">#denominator</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-div">#div</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-divmod">#divmod</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-eql-3F">#eql?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-fdiv">#fdiv</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-floor">#floor</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-i">#i</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-imag">#imag</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-imaginary">#imaginary</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-integer-3F">#integer?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-magnitude">#magnitude</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-modulo">#modulo</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-nonzero-3F">#nonzero?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-numerator">#numerator</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-phase">#phase</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-polar">#polar</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-quo">#quo</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-real">#real</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-real-3F">#real?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-rect">#rect</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-rectangular">#rectangular</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-remainder">#remainder</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-round">#round</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-singleton_method_added">#singleton_method_added</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-step">#step</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-to_c">#to_c</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-to_int">#to_int</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-truncate">#truncate</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Numeric.html#method-i-zero-3F">#zero?</a></li>
             </ul>
         </div>
     </div>
@@ -444,49 +444,49 @@ title:     Ruby Cheat Sheet
         <h2 class="board-title">Object</h2>
         <div class="board-card">
             <ul>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-21-7E">#!~</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-3C-3D-3E">#&lt;=&gt;</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-3D-3D-3D">#===</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-3D-7E">#=~</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-class">#class</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-clone">#clone</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-define_singleton_method">#define_singleton_method</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-display">#display</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-dup">#dup</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-enum_for">#enum_for</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-eql-3F">#eql?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-extend">#extend</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-freeze">#freeze</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-frozen-3F">#frozen?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-hash">#hash</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-inspect">#inspect</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-instance_of-3F">#instance_of?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-instance_variable_defined-3F">#instance_variable_defined?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-instance_variable_get">#instance_variable_get</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-instance_variable_set">#instance_variable_set</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-instance_variables">#instance_variables</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-is_a-3F">#is_a?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-kind_of-3F">#kind_of?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-method">#method</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-nil-3F">#nil?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-object_id">#object_id</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-public_method">#public_method</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-public_send">#public_send</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-remove_instance_variable">#remove_instance_variable</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-respond_to-3F">#respond_to?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-respond_to_missing-3F">#respond_to_missing?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-send">#send</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-singleton_class">#singleton_class</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-singleton_methods">#singleton_methods</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-taint">#taint</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-tainted-3F">#tainted?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-tap">#tap</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-to_enum">#to_enum</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-to_s">#to_s</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-trust">#trust</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-untaint">#untaint</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-untrust">#untrust</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Object.html#method-i-untrusted-3F">#untrusted?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-21-7E">#!~</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-3C-3D-3E">#&lt;=&gt;</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-3D-3D-3D">#===</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-3D-7E">#=~</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-class">#class</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-clone">#clone</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-define_singleton_method">#define_singleton_method</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-display">#display</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-dup">#dup</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-enum_for">#enum_for</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-eql-3F">#eql?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-extend">#extend</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-freeze">#freeze</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-frozen-3F">#frozen?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-hash">#hash</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-inspect">#inspect</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-instance_of-3F">#instance_of?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-instance_variable_defined-3F">#instance_variable_defined?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-instance_variable_get">#instance_variable_get</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-instance_variable_set">#instance_variable_set</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-instance_variables">#instance_variables</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-is_a-3F">#is_a?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-kind_of-3F">#kind_of?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-method">#method</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-nil-3F">#nil?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-object_id">#object_id</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-public_method">#public_method</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-public_send">#public_send</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-remove_instance_variable">#remove_instance_variable</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-respond_to-3F">#respond_to?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-respond_to_missing-3F">#respond_to_missing?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-send">#send</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-singleton_class">#singleton_class</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-singleton_methods">#singleton_methods</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-taint">#taint</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-tainted-3F">#tainted?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-tap">#tap</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-to_enum">#to_enum</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-to_s">#to_s</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-trust">#trust</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-untaint">#untaint</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-untrust">#untrust</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Object.html#method-i-untrusted-3F">#untrusted?</a></li>
             </ul>
         </div>
     </div>
@@ -495,62 +495,62 @@ title:     Ruby Cheat Sheet
         <h2 class="board-title">Hash</h2>
         <div class="board-card">
             <ul>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-c-5B-5D">::[]</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-c-new">::new</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-c-try_convert">::try_convert</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-3D-3D">#==</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-5B-5D">#[]</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-5B-5D-3D">#[]=</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-assoc">#assoc</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-clear">#clear</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-compare_by_identity">#compare_by_identity</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-compare_by_identity-3F">#compare_by_identity?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-default">#default</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-default-3D">#default=</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-default_proc">#default_proc</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-default_proc-3D">#default_proc=</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-delete">#delete</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-delete_if">#delete_if</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-each">#each</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-each_key">#each_key</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-each_pair">#each_pair</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-each_value">#each_value</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-empty-3F">#empty?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-eql-3F">#eql?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-fetch">#fetch</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-flatten">#flatten</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-has_key-3F">#has_key?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-has_value-3F">#has_value?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-hash">#hash</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-include-3F">#include?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-initialize_copy">#initialize_copy</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-inspect">#inspect</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-invert">#invert</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-keep_if">#keep_if</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-key">#key</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-key-3F">#key?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-keys">#keys</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-length">#length</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-member-3F">#member?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-merge">#merge</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-merge-21">#merge!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-rassoc">#rassoc</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-rehash">#rehash</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-reject">#reject</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-reject-21">#reject!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-replace">#replace</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-select">#select</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-select-21">#select!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-shift">#shift</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-size">#size</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-store">#store</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-to_a">#to_a</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-to_hash">#to_hash</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-to_s">#to_s</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-update">#update</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-value-3F">#value?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-values">#values</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Hash.html#method-i-values_at">#values_at</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-c-5B-5D">::[]</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-c-new">::new</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-c-try_convert">::try_convert</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-3D-3D">#==</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-5B-5D">#[]</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-5B-5D-3D">#[]=</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-assoc">#assoc</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-clear">#clear</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-compare_by_identity">#compare_by_identity</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-compare_by_identity-3F">#compare_by_identity?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-default">#default</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-default-3D">#default=</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-default_proc">#default_proc</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-default_proc-3D">#default_proc=</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-delete">#delete</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-delete_if">#delete_if</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-each">#each</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-each_key">#each_key</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-each_pair">#each_pair</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-each_value">#each_value</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-empty-3F">#empty?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-eql-3F">#eql?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-fetch">#fetch</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-flatten">#flatten</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-has_key-3F">#has_key?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-has_value-3F">#has_value?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-hash">#hash</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-include-3F">#include?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-initialize_copy">#initialize_copy</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-inspect">#inspect</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-invert">#invert</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-keep_if">#keep_if</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-key">#key</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-key-3F">#key?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-keys">#keys</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-length">#length</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-member-3F">#member?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-merge">#merge</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-merge-21">#merge!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-rassoc">#rassoc</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-rehash">#rehash</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-reject">#reject</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-reject-21">#reject!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-replace">#replace</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-select">#select</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-select-21">#select!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-shift">#shift</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-size">#size</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-store">#store</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-to_a">#to_a</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-to_hash">#to_hash</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-to_s">#to_s</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-update">#update</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-value-3F">#value?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-values">#values</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Hash.html#method-i-values_at">#values_at</a></li>
             </ul>
         </div>
     </div>
@@ -559,29 +559,29 @@ title:     Ruby Cheat Sheet
         <h2 class="board-title">Regexp</h2>
         <div class="board-card">
             <ul>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Regexp.html#method-c-compile">::compile</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Regexp.html#method-c-escape">::escape</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Regexp.html#method-c-last_match">::last_match</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Regexp.html#method-c-new">::new</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Regexp.html#method-c-quote">::quote</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Regexp.html#method-c-try_convert">::try_convert</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Regexp.html#method-c-union">::union</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Regexp.html#method-i-3D-3D">#==</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Regexp.html#method-i-3D-3D-3D">#===</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Regexp.html#method-i-3D-7E">#=~</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Regexp.html#method-i-casefold-3F">#casefold?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Regexp.html#method-i-encoding">#encoding</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Regexp.html#method-i-eql-3F">#eql?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Regexp.html#method-i-fixed_encoding-3F">#fixed_encoding?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Regexp.html#method-i-hash">#hash</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Regexp.html#method-i-inspect">#inspect</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Regexp.html#method-i-match">#match</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Regexp.html#method-i-named_captures">#named_captures</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Regexp.html#method-i-names">#names</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Regexp.html#method-i-options">#options</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Regexp.html#method-i-source">#source</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Regexp.html#method-i-to_s">#to_s</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Regexp.html#method-i-7E">#~</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Regexp.html#method-c-compile">::compile</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Regexp.html#method-c-escape">::escape</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Regexp.html#method-c-last_match">::last_match</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Regexp.html#method-c-new">::new</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Regexp.html#method-c-quote">::quote</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Regexp.html#method-c-try_convert">::try_convert</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Regexp.html#method-c-union">::union</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Regexp.html#method-i-3D-3D">#==</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Regexp.html#method-i-3D-3D-3D">#===</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Regexp.html#method-i-3D-7E">#=~</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Regexp.html#method-i-casefold-3F">#casefold?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Regexp.html#method-i-encoding">#encoding</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Regexp.html#method-i-eql-3F">#eql?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Regexp.html#method-i-fixed_encoding-3F">#fixed_encoding?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Regexp.html#method-i-hash">#hash</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Regexp.html#method-i-inspect">#inspect</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Regexp.html#method-i-match">#match</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Regexp.html#method-i-named_captures">#named_captures</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Regexp.html#method-i-names">#names</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Regexp.html#method-i-options">#options</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Regexp.html#method-i-source">#source</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Regexp.html#method-i-to_s">#to_s</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Regexp.html#method-i-7E">#~</a></li>
             </ul>
         </div>
     </div>
@@ -591,98 +591,98 @@ title:     Ruby Cheat Sheet
         <div class="board-card">
             <h3 class="board-card-title">Methods</h3>
             <ul>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-c-binread">::binread</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-c-binwrite">::binwrite</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-c-copy_stream">::copy_stream</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-c-for_fd">::for_fd</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-c-foreach">::foreach</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-c-new">::new</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-c-open">::open</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-c-pipe">::pipe</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-c-popen">::popen</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-c-read">::read</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-c-readlines">::readlines</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-c-select">::select</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-c-sysopen">::sysopen</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-c-try_convert">::try_convert</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-c-write">::write</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-3C-3C">#&lt;&lt;</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-advise">#advise</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-autoclose-3D">#autoclose=</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-autoclose-3F">#autoclose?</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-binmode">#binmode</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-binmode-3F">#binmode?</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-bytes">#bytes</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-chars">#chars</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-close">#close</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-close_on_exec-3D">#close_on_exec=</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-close_on_exec-3F">#close_on_exec?</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-close_read">#close_read</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-close_write">#close_write</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-closed-3F">#closed?</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-codepoints">#codepoints</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-each">#each</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-each_byte">#each_byte</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-each_char">#each_char</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-each_codepoint">#each_codepoint</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-each_line">#each_line</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-eof">#eof</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-eof-3F">#eof?</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-external_encoding">#external_encoding</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-fcntl">#fcntl</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-fdatasync">#fdatasync</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-fileno">#fileno</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-flush">#flush</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-fsync">#fsync</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-getbyte">#getbyte</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-getc">#getc</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-gets">#gets</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-inspect">#inspect</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-internal_encoding">#internal_encoding</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-ioctl">#ioctl</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-isatty">#isatty</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-lineno">#lineno</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-lineno-3D">#lineno=</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-lines">#lines</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-pid">#pid</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-pos">#pos</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-pos-3D">#pos=</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-print">#print</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-printf">#printf</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-putc">#putc</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-puts">#puts</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-read">#read</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-read_nonblock">#read_nonblock</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-readbyte">#readbyte</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-readchar">#readchar</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-readline">#readline</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-readlines">#readlines</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-readpartial">#readpartial</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-reopen">#reopen</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-rewind">#rewind</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-seek">#seek</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-set_encoding">#set_encoding</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-stat">#stat</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-sync">#sync</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-sync-3D">#sync=</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-sysread">#sysread</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-sysseek">#sysseek</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-syswrite">#syswrite</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-tell">#tell</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-to_i">#to_i</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-to_io">#to_io</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-tty-3F">#tty?</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-ungetbyte">#ungetbyte</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-ungetc">#ungetc</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-write">#write</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO.html#method-i-write_nonblock">#write_nonblock</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-c-binread">::binread</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-c-binwrite">::binwrite</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-c-copy_stream">::copy_stream</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-c-for_fd">::for_fd</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-c-foreach">::foreach</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-c-new">::new</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-c-open">::open</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-c-pipe">::pipe</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-c-popen">::popen</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-c-read">::read</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-c-readlines">::readlines</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-c-select">::select</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-c-sysopen">::sysopen</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-c-try_convert">::try_convert</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-c-write">::write</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-3C-3C">#&lt;&lt;</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-advise">#advise</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-autoclose-3D">#autoclose=</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-autoclose-3F">#autoclose?</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-binmode">#binmode</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-binmode-3F">#binmode?</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-bytes">#bytes</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-chars">#chars</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-close">#close</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-close_on_exec-3D">#close_on_exec=</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-close_on_exec-3F">#close_on_exec?</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-close_read">#close_read</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-close_write">#close_write</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-closed-3F">#closed?</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-codepoints">#codepoints</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-each">#each</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-each_byte">#each_byte</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-each_char">#each_char</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-each_codepoint">#each_codepoint</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-each_line">#each_line</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-eof">#eof</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-eof-3F">#eof?</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-external_encoding">#external_encoding</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-fcntl">#fcntl</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-fdatasync">#fdatasync</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-fileno">#fileno</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-flush">#flush</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-fsync">#fsync</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-getbyte">#getbyte</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-getc">#getc</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-gets">#gets</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-inspect">#inspect</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-internal_encoding">#internal_encoding</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-ioctl">#ioctl</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-isatty">#isatty</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-lineno">#lineno</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-lineno-3D">#lineno=</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-lines">#lines</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-pid">#pid</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-pos">#pos</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-pos-3D">#pos=</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-print">#print</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-printf">#printf</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-putc">#putc</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-puts">#puts</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-read">#read</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-read_nonblock">#read_nonblock</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-readbyte">#readbyte</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-readchar">#readchar</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-readline">#readline</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-readlines">#readlines</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-readpartial">#readpartial</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-reopen">#reopen</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-rewind">#rewind</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-seek">#seek</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-set_encoding">#set_encoding</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-stat">#stat</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-sync">#sync</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-sync-3D">#sync=</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-sysread">#sysread</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-sysseek">#sysseek</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-syswrite">#syswrite</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-tell">#tell</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-to_i">#to_i</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-to_io">#to_io</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-tty-3F">#tty?</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-ungetbyte">#ungetbyte</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-ungetc">#ungetc</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-write">#write</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO.html#method-i-write_nonblock">#write_nonblock</a></li>
             </ul>
         </div>
         <div class="board-card">
             <h3 class="board-card-title">Namespace</h3>
             <ul>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO/WaitReadable.html">IO::WaitReadable</a></li>
-                <li class=""><a href="http://www.ruby-doc.org/core-1.9.3/IO/WaitWritable.html">IO::WaitWritable</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO/WaitReadable.html">IO::WaitReadable</a></li>
+                <li class=""><a href="http://www.ruby-doc.org/core/IO/WaitWritable.html">IO::WaitWritable</a></li>
             </ul>
         </div>
     </div>
@@ -691,70 +691,70 @@ title:     Ruby Cheat Sheet
         <h2 class="board-title">Time</h2>
         <div class="board-card">
             <ul>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-c-_load">::_load</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-c-at">::at</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-c-gm">::gm</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-c-local">::local</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-c-mktime">::mktime</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-c-new">::new</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-c-now">::now</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-c-utc">::utc</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-2B">#+</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-2D">#-</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-3C-3D-3E">#&lt;=&gt;</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-_dump">#_dump</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-asctime">#asctime</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-ctime">#ctime</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-day">#day</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-dst-3F">#dst?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-eql-3F">#eql?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-friday-3F">#friday?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-getgm">#getgm</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-getlocal">#getlocal</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-getutc">#getutc</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-gmt-3F">#gmt?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-gmt_offset">#gmt_offset</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-gmtime">#gmtime</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-gmtoff">#gmtoff</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-hash">#hash</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-hour">#hour</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-inspect">#inspect</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-isdst">#isdst</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-localtime">#localtime</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-marshal_dump">#marshal_dump</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-marshal_load">#marshal_load</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-mday">#mday</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-min">#min</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-mon">#mon</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-monday-3F">#monday?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-month">#month</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-nsec">#nsec</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-round">#round</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-saturday-3F">#saturday?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-sec">#sec</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-strftime">#strftime</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-subsec">#subsec</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-succ">#succ</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-sunday-3F">#sunday?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-thursday-3F">#thursday?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-to_a">#to_a</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-to_f">#to_f</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-to_i">#to_i</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-to_r">#to_r</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-to_s">#to_s</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-tuesday-3F">#tuesday?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-tv_nsec">#tv_nsec</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-tv_sec">#tv_sec</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-tv_usec">#tv_usec</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-usec">#usec</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-utc">#utc</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-utc-3F">#utc?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-utc_offset">#utc_offset</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-wday">#wday</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-wednesday-3F">#wednesday?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-yday">#yday</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-year">#year</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Time.html#method-i-zone">#zone</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-c-_load">::_load</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-c-at">::at</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-c-gm">::gm</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-c-local">::local</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-c-mktime">::mktime</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-c-new">::new</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-c-now">::now</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-c-utc">::utc</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-2B">#+</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-2D">#-</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-3C-3D-3E">#&lt;=&gt;</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-_dump">#_dump</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-asctime">#asctime</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-ctime">#ctime</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-day">#day</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-dst-3F">#dst?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-eql-3F">#eql?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-friday-3F">#friday?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-getgm">#getgm</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-getlocal">#getlocal</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-getutc">#getutc</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-gmt-3F">#gmt?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-gmt_offset">#gmt_offset</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-gmtime">#gmtime</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-gmtoff">#gmtoff</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-hash">#hash</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-hour">#hour</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-inspect">#inspect</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-isdst">#isdst</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-localtime">#localtime</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-marshal_dump">#marshal_dump</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-marshal_load">#marshal_load</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-mday">#mday</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-min">#min</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-mon">#mon</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-monday-3F">#monday?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-month">#month</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-nsec">#nsec</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-round">#round</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-saturday-3F">#saturday?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-sec">#sec</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-strftime">#strftime</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-subsec">#subsec</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-succ">#succ</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-sunday-3F">#sunday?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-thursday-3F">#thursday?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-to_a">#to_a</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-to_f">#to_f</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-to_i">#to_i</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-to_r">#to_r</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-to_s">#to_s</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-tuesday-3F">#tuesday?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-tv_nsec">#tv_nsec</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-tv_sec">#tv_sec</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-tv_usec">#tv_usec</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-usec">#usec</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-utc">#utc</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-utc-3F">#utc?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-utc_offset">#utc_offset</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-wday">#wday</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-wednesday-3F">#wednesday?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-yday">#yday</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-year">#year</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Time.html#method-i-zone">#zone</a></li>
             </ul>
         </div>
     </div>
@@ -763,57 +763,57 @@ title:     Ruby Cheat Sheet
         <h2 class="board-title">ARGF</h2>
         <div class="board-card">
             <ul>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-argv">#argv</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-binmode">#binmode</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-binmode-3F">#binmode?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-bytes">#bytes</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-chars">#chars</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-close">#close</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-closed-3F">#closed?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-each">#each</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-each_byte">#each_byte</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-each_char">#each_char</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-each_line">#each_line</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-eof">#eof</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-eof-3F">#eof?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-external_encoding">#external_encoding</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-file">#file</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-filename">#filename</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-fileno">#fileno</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-getbyte">#getbyte</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-getc">#getc</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-gets">#gets</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-inplace_mode">#inplace_mode</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-inplace_mode-3D">#inplace_mode=</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-internal_encoding">#internal_encoding</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-lineno">#lineno</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-lineno-3D">#lineno=</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-lines">#lines</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-path">#path</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-pos">#pos</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-pos-3D">#pos=</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-print">#print</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-printf">#printf</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-putc">#putc</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-puts">#puts</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-read">#read</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-read_nonblock">#read_nonblock</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-readbyte">#readbyte</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-readchar">#readchar</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-readline">#readline</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-readlines">#readlines</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-readpartial">#readpartial</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-rewind">#rewind</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-seek">#seek</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-set_encoding">#set_encoding</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-skip">#skip</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-tell">#tell</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-to_a">#to_a</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-to_i">#to_i</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-to_io">#to_io</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-to_s">#to_s</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-to_write_io">#to_write_io</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/ARGF.html#method-i-write">#write</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-argv">#argv</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-binmode">#binmode</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-binmode-3F">#binmode?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-bytes">#bytes</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-chars">#chars</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-close">#close</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-closed-3F">#closed?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-each">#each</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-each_byte">#each_byte</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-each_char">#each_char</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-each_line">#each_line</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-eof">#eof</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-eof-3F">#eof?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-external_encoding">#external_encoding</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-file">#file</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-filename">#filename</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-fileno">#fileno</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-getbyte">#getbyte</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-getc">#getc</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-gets">#gets</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-inplace_mode">#inplace_mode</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-inplace_mode-3D">#inplace_mode=</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-internal_encoding">#internal_encoding</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-lineno">#lineno</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-lineno-3D">#lineno=</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-lines">#lines</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-path">#path</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-pos">#pos</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-pos-3D">#pos=</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-print">#print</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-printf">#printf</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-putc">#putc</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-puts">#puts</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-read">#read</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-read_nonblock">#read_nonblock</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-readbyte">#readbyte</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-readchar">#readchar</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-readline">#readline</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-readlines">#readlines</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-readpartial">#readpartial</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-rewind">#rewind</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-seek">#seek</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-set_encoding">#set_encoding</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-skip">#skip</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-tell">#tell</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-to_a">#to_a</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-to_i">#to_i</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-to_io">#to_io</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-to_s">#to_s</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-to_write_io">#to_write_io</a></li>
+                <li><a href="http://www.ruby-doc.org/core/ARGF.html#method-i-write">#write</a></li>
             </ul>
         </div>
     </div>
@@ -822,19 +822,19 @@ title:     Ruby Cheat Sheet
         <h2 class="board-title">BasicObject</h2>
         <div class="board-card">
             <ul>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/BasicObject.html#method-c-new">::new</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/BasicObject.html#method-i-21">#!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/BasicObject.html#method-i-21-3D">#!=</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/BasicObject.html#method-i-3D-3D">#==</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/BasicObject.html#method-i-__id__">#__id__</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/BasicObject.html#method-i-__send__">#__send__</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/BasicObject.html#method-i-equal-3F">#equal?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/BasicObject.html#method-i-instance_eval">#instance_eval</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/BasicObject.html#method-i-instance_exec">#instance_exec</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/BasicObject.html#method-i-method_missing">#method_missing</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/BasicObject.html#method-i-singleton_method_added">#singleton_method_added</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/BasicObject.html#method-i-singleton_method_removed">#singleton_method_removed</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/BasicObject.html#method-i-singleton_method_undefined">#singleton_method_undefined</a></li>
+                <li><a href="http://www.ruby-doc.org/core/BasicObject.html#method-c-new">::new</a></li>
+                <li><a href="http://www.ruby-doc.org/core/BasicObject.html#method-i-21">#!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/BasicObject.html#method-i-21-3D">#!=</a></li>
+                <li><a href="http://www.ruby-doc.org/core/BasicObject.html#method-i-3D-3D">#==</a></li>
+                <li><a href="http://www.ruby-doc.org/core/BasicObject.html#method-i-__id__">#__id__</a></li>
+                <li><a href="http://www.ruby-doc.org/core/BasicObject.html#method-i-__send__">#__send__</a></li>
+                <li><a href="http://www.ruby-doc.org/core/BasicObject.html#method-i-equal-3F">#equal?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/BasicObject.html#method-i-instance_eval">#instance_eval</a></li>
+                <li><a href="http://www.ruby-doc.org/core/BasicObject.html#method-i-instance_exec">#instance_exec</a></li>
+                <li><a href="http://www.ruby-doc.org/core/BasicObject.html#method-i-method_missing">#method_missing</a></li>
+                <li><a href="http://www.ruby-doc.org/core/BasicObject.html#method-i-singleton_method_added">#singleton_method_added</a></li>
+                <li><a href="http://www.ruby-doc.org/core/BasicObject.html#method-i-singleton_method_removed">#singleton_method_removed</a></li>
+                <li><a href="http://www.ruby-doc.org/core/BasicObject.html#method-i-singleton_method_undefined">#singleton_method_undefined</a></li>
             </ul>
         </div>
     </div>
@@ -843,42 +843,42 @@ title:     Ruby Cheat Sheet
         <h2 class="board-title">Bignum</h2>
         <div class="board-card">
             <ul>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Bignum.html#method-i-25">#%</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Bignum.html#method-i-26">#&amp;</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Bignum.html#method-i-2A">#*</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Bignum.html#method-i-2A-2A">#**</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Bignum.html#method-i-2B">#+</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Bignum.html#method-i-2D">#-</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Bignum.html#method-i-2D-40">#-@</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Bignum.html#method-i-2F">#/</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Bignum.html#method-i-3C">#&lt;</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Bignum.html#method-i-3C-3C">#&lt;&lt;</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Bignum.html#method-i-3C-3D">#&lt;=</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Bignum.html#method-i-3C-3D-3E">#&lt;=&gt;</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Bignum.html#method-i-3D-3D">#==</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Bignum.html#method-i-3D-3D-3D">#===</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Bignum.html#method-i-3E">#&gt;</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Bignum.html#method-i-3E-3D">#&gt;=</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Bignum.html#method-i-3E-3E">#&gt;&gt;</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Bignum.html#method-i-5B-5D">#[]</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Bignum.html#method-i-5E">#^</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Bignum.html#method-i-abs">#abs</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Bignum.html#method-i-coerce">#coerce</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Bignum.html#method-i-div">#div</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Bignum.html#method-i-divmod">#divmod</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Bignum.html#method-i-eql-3F">#eql?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Bignum.html#method-i-even-3F">#even?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Bignum.html#method-i-fdiv">#fdiv</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Bignum.html#method-i-hash">#hash</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Bignum.html#method-i-magnitude">#magnitude</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Bignum.html#method-i-modulo">#modulo</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Bignum.html#method-i-odd-3F">#odd?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Bignum.html#method-i-remainder">#remainder</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Bignum.html#method-i-size">#size</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Bignum.html#method-i-to_f">#to_f</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Bignum.html#method-i-to_s">#to_s</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Bignum.html#method-i-7C">#|</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Bignum.html#method-i-7E">#~</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Bignum.html#method-i-25">#%</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Bignum.html#method-i-26">#&amp;</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Bignum.html#method-i-2A">#*</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Bignum.html#method-i-2A-2A">#**</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Bignum.html#method-i-2B">#+</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Bignum.html#method-i-2D">#-</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Bignum.html#method-i-2D-40">#-@</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Bignum.html#method-i-2F">#/</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Bignum.html#method-i-3C">#&lt;</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Bignum.html#method-i-3C-3C">#&lt;&lt;</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Bignum.html#method-i-3C-3D">#&lt;=</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Bignum.html#method-i-3C-3D-3E">#&lt;=&gt;</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Bignum.html#method-i-3D-3D">#==</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Bignum.html#method-i-3D-3D-3D">#===</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Bignum.html#method-i-3E">#&gt;</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Bignum.html#method-i-3E-3D">#&gt;=</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Bignum.html#method-i-3E-3E">#&gt;&gt;</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Bignum.html#method-i-5B-5D">#[]</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Bignum.html#method-i-5E">#^</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Bignum.html#method-i-abs">#abs</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Bignum.html#method-i-coerce">#coerce</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Bignum.html#method-i-div">#div</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Bignum.html#method-i-divmod">#divmod</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Bignum.html#method-i-eql-3F">#eql?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Bignum.html#method-i-even-3F">#even?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Bignum.html#method-i-fdiv">#fdiv</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Bignum.html#method-i-hash">#hash</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Bignum.html#method-i-magnitude">#magnitude</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Bignum.html#method-i-modulo">#modulo</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Bignum.html#method-i-odd-3F">#odd?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Bignum.html#method-i-remainder">#remainder</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Bignum.html#method-i-size">#size</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Bignum.html#method-i-to_f">#to_f</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Bignum.html#method-i-to_s">#to_s</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Bignum.html#method-i-7C">#|</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Bignum.html#method-i-7E">#~</a></li>
             </ul>
         </div>
     </div>
@@ -887,11 +887,11 @@ title:     Ruby Cheat Sheet
         <h2 class="board-title">Class</h2>
         <div class="board-card">
             <ul>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Class.html#method-c-new">::new</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Class.html#method-i-allocate">#allocate</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Class.html#method-i-inherited">#inherited</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Class.html#method-i-new">#new</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Class.html#method-i-superclass">#superclass</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Class.html#method-c-new">::new</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Class.html#method-i-allocate">#allocate</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Class.html#method-i-inherited">#inherited</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Class.html#method-i-new">#new</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Class.html#method-i-superclass">#superclass</a></li>
             </ul>
         </div>
     </div>
@@ -900,42 +900,42 @@ title:     Ruby Cheat Sheet
         <h2 class="board-title">Complex</h2>
         <div class="board-card">
             <ul>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Complex.html#method-c-polar">::polar</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Complex.html#method-c-rect">::rect</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Complex.html#method-c-rectangular">::rectangular</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Complex.html#method-i-2A">#*</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Complex.html#method-i-2A-2A">#**</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Complex.html#method-i-2B">#+</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Complex.html#method-i-2D">#-</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Complex.html#method-i-2D-40">#-@</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Complex.html#method-i-2F">#/</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Complex.html#method-i-3D-3D">#==</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Complex.html#method-i-abs">#abs</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Complex.html#method-i-abs2">#abs2</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Complex.html#method-i-angle">#angle</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Complex.html#method-i-arg">#arg</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Complex.html#method-i-conj">#conj</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Complex.html#method-i-conjugate">#conjugate</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Complex.html#method-i-denominator">#denominator</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Complex.html#method-i-fdiv">#fdiv</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Complex.html#method-i-imag">#imag</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Complex.html#method-i-imaginary">#imaginary</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Complex.html#method-i-inspect">#inspect</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Complex.html#method-i-magnitude">#magnitude</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Complex.html#method-i-numerator">#numerator</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Complex.html#method-i-phase">#phase</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Complex.html#method-i-polar">#polar</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Complex.html#method-i-quo">#quo</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Complex.html#method-i-rationalize">#rationalize</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Complex.html#method-i-real">#real</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Complex.html#method-i-real-3F">#real?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Complex.html#method-i-rect">#rect</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Complex.html#method-i-rectangular">#rectangular</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Complex.html#method-i-to_f">#to_f</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Complex.html#method-i-to_i">#to_i</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Complex.html#method-i-to_r">#to_r</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Complex.html#method-i-to_s">#to_s</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Complex.html#method-i-7E">#~</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Complex.html#method-c-polar">::polar</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Complex.html#method-c-rect">::rect</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Complex.html#method-c-rectangular">::rectangular</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Complex.html#method-i-2A">#*</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Complex.html#method-i-2A-2A">#**</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Complex.html#method-i-2B">#+</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Complex.html#method-i-2D">#-</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Complex.html#method-i-2D-40">#-@</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Complex.html#method-i-2F">#/</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Complex.html#method-i-3D-3D">#==</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Complex.html#method-i-abs">#abs</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Complex.html#method-i-abs2">#abs2</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Complex.html#method-i-angle">#angle</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Complex.html#method-i-arg">#arg</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Complex.html#method-i-conj">#conj</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Complex.html#method-i-conjugate">#conjugate</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Complex.html#method-i-denominator">#denominator</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Complex.html#method-i-fdiv">#fdiv</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Complex.html#method-i-imag">#imag</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Complex.html#method-i-imaginary">#imaginary</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Complex.html#method-i-inspect">#inspect</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Complex.html#method-i-magnitude">#magnitude</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Complex.html#method-i-numerator">#numerator</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Complex.html#method-i-phase">#phase</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Complex.html#method-i-polar">#polar</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Complex.html#method-i-quo">#quo</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Complex.html#method-i-rationalize">#rationalize</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Complex.html#method-i-real">#real</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Complex.html#method-i-real-3F">#real?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Complex.html#method-i-rect">#rect</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Complex.html#method-i-rectangular">#rectangular</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Complex.html#method-i-to_f">#to_f</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Complex.html#method-i-to_i">#to_i</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Complex.html#method-i-to_r">#to_r</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Complex.html#method-i-to_s">#to_s</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Complex.html#method-i-7E">#~</a></li>
             </ul>
         </div>
     </div>
@@ -945,33 +945,33 @@ title:     Ruby Cheat Sheet
         <div class="board-card">
             <h3 class="board-card-title">Methods</h3>
             <ul>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Encoding.html#method-c-aliases">::aliases</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Encoding.html#method-c-compatible-3F">::compatible?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Encoding.html#method-c-default_external">::default_external</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Encoding.html#method-c-default_external-3D">::default_external=</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Encoding.html#method-c-default_internal">::default_internal</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Encoding.html#method-c-default_internal-3D">::default_internal=</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Encoding.html#method-c-find">::find</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Encoding.html#method-c-list">::list</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Encoding.html#method-c-locale_charmap">::locale_charmap</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Encoding.html#method-c-name_list">::name_list</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Encoding.html#method-i-ascii_compatible-3F">#ascii_compatible?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Encoding.html#method-i-dummy-3F">#dummy?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Encoding.html#method-i-inspect">#inspect</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Encoding.html#method-i-name">#name</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Encoding.html#method-i-names">#names</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Encoding.html#method-i-replicate">#replicate</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Encoding.html#method-i-to_s">#to_s</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Encoding.html#method-c-aliases">::aliases</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Encoding.html#method-c-compatible-3F">::compatible?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Encoding.html#method-c-default_external">::default_external</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Encoding.html#method-c-default_external-3D">::default_external=</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Encoding.html#method-c-default_internal">::default_internal</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Encoding.html#method-c-default_internal-3D">::default_internal=</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Encoding.html#method-c-find">::find</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Encoding.html#method-c-list">::list</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Encoding.html#method-c-locale_charmap">::locale_charmap</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Encoding.html#method-c-name_list">::name_list</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Encoding.html#method-i-ascii_compatible-3F">#ascii_compatible?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Encoding.html#method-i-dummy-3F">#dummy?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Encoding.html#method-i-inspect">#inspect</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Encoding.html#method-i-name">#name</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Encoding.html#method-i-names">#names</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Encoding.html#method-i-replicate">#replicate</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Encoding.html#method-i-to_s">#to_s</a></li>
             </ul>
         </div>
         <div class="board-card">
             <h3 class="board-card-title">Namespace</h3>
             <ul>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Encoding/CompatibilityError.html">Encoding::CompatibilityError</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Encoding/Converter.html">Encoding::Converter</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Encoding/ConverterNotFoundError.html">Encoding::ConverterNotFoundError</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Encoding/InvalidByteSequenceError.html">Encoding::InvalidByteSequenceError</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Encoding/UndefinedConversionError.html">Encoding::UndefinedConversionError</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Encoding/CompatibilityError.html">Encoding::CompatibilityError</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Encoding/Converter.html">Encoding::Converter</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Encoding/ConverterNotFoundError.html">Encoding::ConverterNotFoundError</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Encoding/InvalidByteSequenceError.html">Encoding::InvalidByteSequenceError</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Encoding/UndefinedConversionError.html">Encoding::UndefinedConversionError</a></li>
             </ul>
         </div>
     </div>
@@ -981,26 +981,26 @@ title:     Ruby Cheat Sheet
         <div class="board-card">
             <h3 class="board-card-title">Methods</h3>
             <ul>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Enumerator.html#method-c-new">::new</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Enumerator.html#method-i-each">#each</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Enumerator.html#method-i-each_with_index">#each_with_index</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Enumerator.html#method-i-each_with_object">#each_with_object</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Enumerator.html#method-i-feed">#feed</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Enumerator.html#method-i-inspect">#inspect</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Enumerator.html#method-i-next">#next</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Enumerator.html#method-i-next_values">#next_values</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Enumerator.html#method-i-peek">#peek</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Enumerator.html#method-i-peek_values">#peek_values</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Enumerator.html#method-i-rewind">#rewind</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Enumerator.html#method-i-with_index">#with_index</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Enumerator.html#method-i-with_object">#with_object</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Enumerator.html#method-c-new">::new</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Enumerator.html#method-i-each">#each</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Enumerator.html#method-i-each_with_index">#each_with_index</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Enumerator.html#method-i-each_with_object">#each_with_object</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Enumerator.html#method-i-feed">#feed</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Enumerator.html#method-i-inspect">#inspect</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Enumerator.html#method-i-next">#next</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Enumerator.html#method-i-next_values">#next_values</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Enumerator.html#method-i-peek">#peek</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Enumerator.html#method-i-peek_values">#peek_values</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Enumerator.html#method-i-rewind">#rewind</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Enumerator.html#method-i-with_index">#with_index</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Enumerator.html#method-i-with_object">#with_object</a></li>
             </ul>
         </div>
         <div class="board-card">
             <h3 class="board-card-title">Namespace</h3>
             <ul>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Enumerator/Generator.html">Enumerator::Generator</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Enumerator/Yielder.html">Enumerator::Yielder</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Enumerator/Generator.html">Enumerator::Generator</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Enumerator/Yielder.html">Enumerator::Yielder</a></li>
             </ul>
         </div>
     </div>
@@ -1009,15 +1009,15 @@ title:     Ruby Cheat Sheet
         <h2 class="board-title">Exception</h2>
         <div class="board-card">
             <ul>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Exception.html#method-c-exception">::exception</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Exception.html#method-c-new">::new</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Exception.html#method-i-3D-3D">#==</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Exception.html#method-i-backtrace">#backtrace</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Exception.html#method-i-exception">#exception</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Exception.html#method-i-inspect">#inspect</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Exception.html#method-i-message">#message</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Exception.html#method-i-set_backtrace">#set_backtrace</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Exception.html#method-i-to_s">#to_s</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Exception.html#method-c-exception">::exception</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Exception.html#method-c-new">::new</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Exception.html#method-i-3D-3D">#==</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Exception.html#method-i-backtrace">#backtrace</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Exception.html#method-i-exception">#exception</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Exception.html#method-i-inspect">#inspect</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Exception.html#method-i-message">#message</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Exception.html#method-i-set_backtrace">#set_backtrace</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Exception.html#method-i-to_s">#to_s</a></li>
             </ul>
         </div>
     </div>
@@ -1026,11 +1026,11 @@ title:     Ruby Cheat Sheet
         <h2 class="board-title">Fiber</h2>
         <div class="board-card">
             <ul>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fiber.html#method-c-current">::current</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fiber.html#method-c-yield">::yield</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fiber.html#method-i-alive-3F">#alive?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fiber.html#method-i-resume">#resume</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fiber.html#method-i-transfer">#transfer</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fiber.html#method-c-current">::current</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fiber.html#method-c-yield">::yield</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fiber.html#method-i-alive-3F">#alive?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fiber.html#method-i-resume">#resume</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fiber.html#method-i-transfer">#transfer</a></li>
             </ul>
         </div>
     </div>
@@ -1039,48 +1039,48 @@ title:     Ruby Cheat Sheet
         <h2 class="board-title">Float</h2>
         <div class="board-card">
             <ul>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-25">#%</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-2A">#*</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-2A-2A">#**</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-2B">#+</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-2D">#-</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-2D-40">#-@</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-2F">#/</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-3C">#&lt;</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-3C-3D">#&lt;=</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-3C-3D-3E">#&lt;=&gt;</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-3D-3D">#==</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-3D-3D-3D">#===</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-3E">#&gt;</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-3E-3D">#&gt;=</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-abs">#abs</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-angle">#angle</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-arg">#arg</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-ceil">#ceil</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-coerce">#coerce</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-denominator">#denominator</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-divmod">#divmod</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-eql-3F">#eql?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-fdiv">#fdiv</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-finite-3F">#finite?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-floor">#floor</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-hash">#hash</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-infinite-3F">#infinite?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-magnitude">#magnitude</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-modulo">#modulo</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-nan-3F">#nan?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-numerator">#numerator</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-phase">#phase</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-quo">#quo</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-rationalize">#rationalize</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-round">#round</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-to_f">#to_f</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-to_i">#to_i</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-to_int">#to_int</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-to_r">#to_r</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-to_s">#to_s</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-truncate">#truncate</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Float.html#method-i-zero-3F">#zero?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-25">#%</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-2A">#*</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-2A-2A">#**</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-2B">#+</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-2D">#-</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-2D-40">#-@</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-2F">#/</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-3C">#&lt;</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-3C-3D">#&lt;=</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-3C-3D-3E">#&lt;=&gt;</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-3D-3D">#==</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-3D-3D-3D">#===</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-3E">#&gt;</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-3E-3D">#&gt;=</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-abs">#abs</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-angle">#angle</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-arg">#arg</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-ceil">#ceil</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-coerce">#coerce</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-denominator">#denominator</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-divmod">#divmod</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-eql-3F">#eql?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-fdiv">#fdiv</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-finite-3F">#finite?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-floor">#floor</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-hash">#hash</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-infinite-3F">#infinite?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-magnitude">#magnitude</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-modulo">#modulo</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-nan-3F">#nan?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-numerator">#numerator</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-phase">#phase</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-quo">#quo</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-rationalize">#rationalize</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-round">#round</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-to_f">#to_f</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-to_i">#to_i</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-to_int">#to_int</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-to_r">#to_r</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-to_s">#to_s</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-truncate">#truncate</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Float.html#method-i-zero-3F">#zero?</a></li>
             </ul>
         </div>
     </div>
@@ -1089,40 +1089,40 @@ title:     Ruby Cheat Sheet
         <h2 class="board-title">Fixnum</h2>
         <div class="board-card">
             <ul>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fixnum.html#method-i-25">#%</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fixnum.html#method-i-26">#&amp;</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fixnum.html#method-i-2A">#*</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fixnum.html#method-i-2A-2A">#**</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fixnum.html#method-i-2B">#+</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fixnum.html#method-i-2D">#-</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fixnum.html#method-i-2D-40">#-@</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fixnum.html#method-i-2F">#/</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fixnum.html#method-i-3C">#&lt;</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fixnum.html#method-i-3C-3C">#&lt;&lt;</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fixnum.html#method-i-3C-3D">#&lt;=</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fixnum.html#method-i-3C-3D-3E">#&lt;=&gt;</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fixnum.html#method-i-3D-3D">#==</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fixnum.html#method-i-3D-3D-3D">#===</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fixnum.html#method-i-3E">#&gt;</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fixnum.html#method-i-3E-3D">#&gt;=</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fixnum.html#method-i-3E-3E">#&gt;&gt;</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fixnum.html#method-i-5B-5D">#[]</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fixnum.html#method-i-5E">#^</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fixnum.html#method-i-abs">#abs</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fixnum.html#method-i-div">#div</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fixnum.html#method-i-divmod">#divmod</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fixnum.html#method-i-even-3F">#even?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fixnum.html#method-i-fdiv">#fdiv</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fixnum.html#method-i-magnitude">#magnitude</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fixnum.html#method-i-modulo">#modulo</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fixnum.html#method-i-odd-3F">#odd?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fixnum.html#method-i-size">#size</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fixnum.html#method-i-succ">#succ</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fixnum.html#method-i-to_f">#to_f</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fixnum.html#method-i-to_s">#to_s</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fixnum.html#method-i-zero-3F">#zero?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fixnum.html#method-i-7C">#|</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Fixnum.html#method-i-7E">#~</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fixnum.html#method-i-25">#%</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fixnum.html#method-i-26">#&amp;</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fixnum.html#method-i-2A">#*</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fixnum.html#method-i-2A-2A">#**</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fixnum.html#method-i-2B">#+</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fixnum.html#method-i-2D">#-</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fixnum.html#method-i-2D-40">#-@</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fixnum.html#method-i-2F">#/</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fixnum.html#method-i-3C">#&lt;</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fixnum.html#method-i-3C-3C">#&lt;&lt;</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fixnum.html#method-i-3C-3D">#&lt;=</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fixnum.html#method-i-3C-3D-3E">#&lt;=&gt;</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fixnum.html#method-i-3D-3D">#==</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fixnum.html#method-i-3D-3D-3D">#===</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fixnum.html#method-i-3E">#&gt;</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fixnum.html#method-i-3E-3D">#&gt;=</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fixnum.html#method-i-3E-3E">#&gt;&gt;</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fixnum.html#method-i-5B-5D">#[]</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fixnum.html#method-i-5E">#^</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fixnum.html#method-i-abs">#abs</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fixnum.html#method-i-div">#div</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fixnum.html#method-i-divmod">#divmod</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fixnum.html#method-i-even-3F">#even?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fixnum.html#method-i-fdiv">#fdiv</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fixnum.html#method-i-magnitude">#magnitude</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fixnum.html#method-i-modulo">#modulo</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fixnum.html#method-i-odd-3F">#odd?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fixnum.html#method-i-size">#size</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fixnum.html#method-i-succ">#succ</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fixnum.html#method-i-to_f">#to_f</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fixnum.html#method-i-to_s">#to_s</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fixnum.html#method-i-zero-3F">#zero?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fixnum.html#method-i-7C">#|</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Fixnum.html#method-i-7E">#~</a></li>
             </ul>
         </div>
     </div>
@@ -1131,69 +1131,69 @@ title:     Ruby Cheat Sheet
         <h2 class="board-title">Kernel</h2>
         <div class="board-card">
             <ul>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-Array">#Array</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-Complex">#Complex</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-Float">#Float</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-Integer">#Integer</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-Rational">#Rational</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-String">#String</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-__callee__">#__callee__</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-__method__">#__method__</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-60">#`</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-abort">#abort</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-at_exit">#at_exit</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-autoload">#autoload</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-autoload-3F">#autoload?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-binding">#binding</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-block_given-3F">#block_given?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-callcc">#callcc</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-caller">#caller</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-catch">#catch</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-chomp">#chomp</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-chop">#chop</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-eval">#eval</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-exec">#exec</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-exit">#exit</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-exit-21">#exit!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-fail">#fail</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-fork">#fork</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-format">#format</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-gets">#gets</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-global_variables">#global_variables</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-gsub">#gsub</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-iterator-3F">#iterator?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-lambda">#lambda</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-load">#load</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-local_variables">#local_variables</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-loop">#loop</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-open">#open</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-p">#p</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-print">#print</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-printf">#printf</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-proc">#proc</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-putc">#putc</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-puts">#puts</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-raise">#raise</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-rand">#rand</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-readline">#readline</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-readlines">#readlines</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-require">#require</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-require_relative">#require_relative</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-select">#select</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-set_trace_func">#set_trace_func</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-sleep">#sleep</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-spawn">#spawn</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-sprintf">#sprintf</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-srand">#srand</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-sub">#sub</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-syscall">#syscall</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-system">#system</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-test">#test</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-throw">#throw</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-trace_var">#trace_var</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-trap">#trap</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-untrace_var">#untrace_var</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-warn">#warn</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-Array">#Array</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-Complex">#Complex</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-Float">#Float</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-Integer">#Integer</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-Rational">#Rational</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-String">#String</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-__callee__">#__callee__</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-__method__">#__method__</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-60">#`</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-abort">#abort</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-at_exit">#at_exit</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-autoload">#autoload</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-autoload-3F">#autoload?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-binding">#binding</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-block_given-3F">#block_given?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-callcc">#callcc</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-caller">#caller</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-catch">#catch</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-chomp">#chomp</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-chop">#chop</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-eval">#eval</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-exec">#exec</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-exit">#exit</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-exit-21">#exit!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-fail">#fail</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-fork">#fork</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-format">#format</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-gets">#gets</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-global_variables">#global_variables</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-gsub">#gsub</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-iterator-3F">#iterator?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-lambda">#lambda</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-load">#load</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-local_variables">#local_variables</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-loop">#loop</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-open">#open</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-p">#p</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-print">#print</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-printf">#printf</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-proc">#proc</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-putc">#putc</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-puts">#puts</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-raise">#raise</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-rand">#rand</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-readline">#readline</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-readlines">#readlines</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-require">#require</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-require_relative">#require_relative</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-select">#select</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-set_trace_func">#set_trace_func</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-sleep">#sleep</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-spawn">#spawn</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-sprintf">#sprintf</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-srand">#srand</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-sub">#sub</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-syscall">#syscall</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-system">#system</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-test">#test</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-throw">#throw</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-trace_var">#trace_var</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-trap">#trap</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-untrace_var">#untrace_var</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Kernel.html#method-i-warn">#warn</a></li>
             </ul>
         </div>
     </div>
@@ -1202,22 +1202,22 @@ title:     Ruby Cheat Sheet
         <h2 class="board-title">Method</h2>
         <div class="board-card">
             <ul>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Method.html#method-i-3D-3D">#==</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Method.html#method-i-5B-5D">#[]</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Method.html#method-i-arity">#arity</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Method.html#method-i-call">#call</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Method.html#method-i-clone">#clone</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Method.html#method-i-eql-3F">#eql?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Method.html#method-i-hash">#hash</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Method.html#method-i-inspect">#inspect</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Method.html#method-i-name">#name</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Method.html#method-i-owner">#owner</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Method.html#method-i-parameters">#parameters</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Method.html#method-i-receiver">#receiver</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Method.html#method-i-source_location">#source_location</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Method.html#method-i-to_proc">#to_proc</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Method.html#method-i-to_s">#to_s</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Method.html#method-i-unbind">#unbind</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Method.html#method-i-3D-3D">#==</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Method.html#method-i-5B-5D">#[]</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Method.html#method-i-arity">#arity</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Method.html#method-i-call">#call</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Method.html#method-i-clone">#clone</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Method.html#method-i-eql-3F">#eql?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Method.html#method-i-hash">#hash</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Method.html#method-i-inspect">#inspect</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Method.html#method-i-name">#name</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Method.html#method-i-owner">#owner</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Method.html#method-i-parameters">#parameters</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Method.html#method-i-receiver">#receiver</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Method.html#method-i-source_location">#source_location</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Method.html#method-i-to_proc">#to_proc</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Method.html#method-i-to_s">#to_s</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Method.html#method-i-unbind">#unbind</a></li>
             </ul>
         </div>
     </div>
@@ -1226,71 +1226,71 @@ title:     Ruby Cheat Sheet
         <h2 class="board-title">Module</h2>
         <div class="board-card">
             <ul>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-c-constants">::constants</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-c-nesting">::nesting</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-c-new">::new</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-3C">#&lt;</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-3C-3D">#&lt;=</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-3C-3D-3E">#&lt;=&gt;</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-3D-3D">#==</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-3D-3D-3D">#===</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-3E">#&gt;</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-3E-3D">#&gt;=</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-alias_method">#alias_method</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-ancestors">#ancestors</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-append_features">#append_features</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-attr">#attr</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-attr_accessor">#attr_accessor</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-attr_reader">#attr_reader</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-attr_writer">#attr_writer</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-autoload">#autoload</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-autoload-3F">#autoload?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-class_eval">#class_eval</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-class_exec">#class_exec</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-class_variable_defined-3F">#class_variable_defined?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-class_variable_get">#class_variable_get</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-class_variable_set">#class_variable_set</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-class_variables">#class_variables</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-const_defined-3F">#const_defined?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-const_get">#const_get</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-const_missing">#const_missing</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-const_set">#const_set</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-constants">#constants</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-define_method">#define_method</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-extend_object">#extend_object</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-extended">#extended</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-freeze">#freeze</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-include">#include</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-include-3F">#include?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-included">#included</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-included_modules">#included_modules</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-instance_method">#instance_method</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-instance_methods">#instance_methods</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-method_added">#method_added</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-method_defined-3F">#method_defined?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-method_removed">#method_removed</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-method_undefined">#method_undefined</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-module_eval">#module_eval</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-module_exec">#module_exec</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-module_function">#module_function</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-name">#name</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-private">#private</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-private_class_method">#private_class_method</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-private_instance_methods">#private_instance_methods</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-private_method_defined-3F">#private_method_defined?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-protected">#protected</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-protected_instance_methods">#protected_instance_methods</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-protected_method_defined-3F">#protected_method_defined?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-public">#public</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-public_class_method">#public_class_method</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-public_instance_method">#public_instance_method</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-public_instance_methods">#public_instance_methods</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-public_method_defined-3F">#public_method_defined?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-remove_class_variable">#remove_class_variable</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-remove_const">#remove_const</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-remove_method">#remove_method</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-to_s">#to_s</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-undef_method">#undef_method</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-c-constants">::constants</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-c-nesting">::nesting</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-c-new">::new</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-3C">#&lt;</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-3C-3D">#&lt;=</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-3C-3D-3E">#&lt;=&gt;</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-3D-3D">#==</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-3D-3D-3D">#===</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-3E">#&gt;</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-3E-3D">#&gt;=</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-alias_method">#alias_method</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-ancestors">#ancestors</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-append_features">#append_features</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-attr">#attr</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-attr_accessor">#attr_accessor</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-attr_reader">#attr_reader</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-attr_writer">#attr_writer</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-autoload">#autoload</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-autoload-3F">#autoload?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-class_eval">#class_eval</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-class_exec">#class_exec</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-class_variable_defined-3F">#class_variable_defined?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-class_variable_get">#class_variable_get</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-class_variable_set">#class_variable_set</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-class_variables">#class_variables</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-const_defined-3F">#const_defined?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-const_get">#const_get</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-const_missing">#const_missing</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-const_set">#const_set</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-constants">#constants</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-define_method">#define_method</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-extend_object">#extend_object</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-extended">#extended</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-freeze">#freeze</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-include">#include</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-include-3F">#include?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-included">#included</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-included_modules">#included_modules</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-instance_method">#instance_method</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-instance_methods">#instance_methods</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-method_added">#method_added</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-method_defined-3F">#method_defined?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-method_removed">#method_removed</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-method_undefined">#method_undefined</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-module_eval">#module_eval</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-module_exec">#module_exec</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-module_function">#module_function</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-name">#name</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-private">#private</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-private_class_method">#private_class_method</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-private_instance_methods">#private_instance_methods</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-private_method_defined-3F">#private_method_defined?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-protected">#protected</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-protected_instance_methods">#protected_instance_methods</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-protected_method_defined-3F">#protected_method_defined?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-public">#public</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-public_class_method">#public_class_method</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-public_instance_method">#public_instance_method</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-public_instance_methods">#public_instance_methods</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-public_method_defined-3F">#public_method_defined?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-remove_class_variable">#remove_class_variable</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-remove_const">#remove_const</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-remove_method">#remove_method</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-to_s">#to_s</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Module.html#method-i-undef_method">#undef_method</a></li>
             </ul>
         </div>
     </div>
@@ -1299,22 +1299,22 @@ title:     Ruby Cheat Sheet
         <h2 class="board-title">Proc</h2>
         <div class="board-card">
             <ul>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Proc.html#method-c-new">::new</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Proc.html#method-i-3D-3D">#==</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Proc.html#method-i-3D-3D-3D">#===</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Proc.html#method-i-5B-5D">#[]</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Proc.html#method-i-arity">#arity</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Proc.html#method-i-binding">#binding</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Proc.html#method-i-call">#call</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Proc.html#method-i-curry">#curry</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Proc.html#method-i-eql-3F">#eql?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Proc.html#method-i-hash">#hash</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Proc.html#method-i-lambda-3F">#lambda?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Proc.html#method-i-parameters">#parameters</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Proc.html#method-i-source_location">#source_location</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Proc.html#method-i-to_proc">#to_proc</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Proc.html#method-i-to_s">#to_s</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Proc.html#method-i-yield">#yield</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Proc.html#method-c-new">::new</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Proc.html#method-i-3D-3D">#==</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Proc.html#method-i-3D-3D-3D">#===</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Proc.html#method-i-5B-5D">#[]</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Proc.html#method-i-arity">#arity</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Proc.html#method-i-binding">#binding</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Proc.html#method-i-call">#call</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Proc.html#method-i-curry">#curry</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Proc.html#method-i-eql-3F">#eql?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Proc.html#method-i-hash">#hash</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Proc.html#method-i-lambda-3F">#lambda?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Proc.html#method-i-parameters">#parameters</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Proc.html#method-i-source_location">#source_location</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Proc.html#method-i-to_proc">#to_proc</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Proc.html#method-i-to_s">#to_s</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Proc.html#method-i-yield">#yield</a></li>
             </ul>
         </div>
     </div>
@@ -1324,54 +1324,54 @@ title:     Ruby Cheat Sheet
         <div class="board-card">
             <h3 class="board-card-title">Methods</h3>
             <ul>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-abort">::abort</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-daemon">::daemon</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-detach">::detach</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-egid">::egid</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-egid-3D">::egid=</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-euid">::euid</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-euid-3D">::euid=</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-exec">::exec</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-exit">::exit</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-exit-21">::exit!</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-fork">::fork</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-getpgid">::getpgid</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-getpgrp">::getpgrp</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-getpriority">::getpriority</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-getrlimit">::getrlimit</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-gid">::gid</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-gid-3D">::gid=</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-groups">::groups</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-groups-3D">::groups=</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-initgroups">::initgroups</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-kill">::kill</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-maxgroups">::maxgroups</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-maxgroups-3D">::maxgroups=</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-pid">::pid</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-ppid">::ppid</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-setpgid">::setpgid</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-setpgrp">::setpgrp</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-setpriority">::setpriority</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-setrlimit">::setrlimit</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-setsid">::setsid</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-spawn">::spawn</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-times">::times</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-uid">::uid</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-uid-3D">::uid=</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-wait">::wait</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-wait2">::wait2</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-waitall">::waitall</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-waitpid">::waitpid</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-waitpid2">::waitpid2</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-abort">::abort</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-daemon">::daemon</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-detach">::detach</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-egid">::egid</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-egid-3D">::egid=</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-euid">::euid</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-euid-3D">::euid=</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-exec">::exec</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-exit">::exit</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-exit-21">::exit!</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-fork">::fork</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-getpgid">::getpgid</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-getpgrp">::getpgrp</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-getpriority">::getpriority</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-getrlimit">::getrlimit</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-gid">::gid</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-gid-3D">::gid=</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-groups">::groups</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-groups-3D">::groups=</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-initgroups">::initgroups</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-kill">::kill</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-maxgroups">::maxgroups</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-maxgroups-3D">::maxgroups=</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-pid">::pid</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-ppid">::ppid</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-setpgid">::setpgid</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-setpgrp">::setpgrp</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-setpriority">::setpriority</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-setrlimit">::setrlimit</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-setsid">::setsid</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-spawn">::spawn</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-times">::times</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-uid">::uid</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-uid-3D">::uid=</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-wait">::wait</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-wait2">::wait2</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-waitall">::waitall</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-waitpid">::waitpid</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process.html#method-c-waitpid2">::waitpid2</a></li>
             </ul>
         </div>
         <div class="board-card">
             <h3 class="board-card-title">Namespace</h3>
             <ul>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process/GID.html">Process::GID</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process/Sys.html">Process::Sys</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process/UID.html">Process::UID</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Process/Status.html">Process::Status</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process/GID.html">Process::GID</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process/Sys.html">Process::Sys</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process/UID.html">Process::UID</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Process/Status.html">Process::Status</a></li>
             </ul>
         </div>
     </div>
@@ -1380,14 +1380,14 @@ title:     Ruby Cheat Sheet
         <h2 class="board-title">Random</h2>
         <div class="board-card">
             <ul>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Random.html#method-c-new">::new</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Random.html#method-c-new_seed">::new_seed</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Random.html#method-c-rand">::rand</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Random.html#method-c-srand">::srand</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Random.html#method-i-3D-3D">#==</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Random.html#method-i-bytes">#bytes</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Random.html#method-i-rand">#rand</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Random.html#method-i-seed">#seed</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Random.html#method-c-new">::new</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Random.html#method-c-new_seed">::new_seed</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Random.html#method-c-rand">::rand</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Random.html#method-c-srand">::srand</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Random.html#method-i-3D-3D">#==</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Random.html#method-i-bytes">#bytes</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Random.html#method-i-rand">#rand</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Random.html#method-i-seed">#seed</a></li>
             </ul>
         </div>
     </div>
@@ -1396,25 +1396,25 @@ title:     Ruby Cheat Sheet
         <h2 class="board-title">Range</h2>
         <div class="board-card">
             <ul>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Range.html#method-c-new">::new</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Range.html#method-i-3D-3D">#==</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Range.html#method-i-3D-3D-3D">#===</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Range.html#method-i-begin">#begin</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Range.html#method-i-cover-3F">#cover?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Range.html#method-i-each">#each</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Range.html#method-i-end">#end</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Range.html#method-i-eql-3F">#eql?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Range.html#method-i-exclude_end-3F">#exclude_end?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Range.html#method-i-first">#first</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Range.html#method-i-hash">#hash</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Range.html#method-i-include-3F">#include?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Range.html#method-i-inspect">#inspect</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Range.html#method-i-last">#last</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Range.html#method-i-max">#max</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Range.html#method-i-member-3F">#member?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Range.html#method-i-min">#min</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Range.html#method-i-step">#step</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Range.html#method-i-to_s">#to_s</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Range.html#method-c-new">::new</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Range.html#method-i-3D-3D">#==</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Range.html#method-i-3D-3D-3D">#===</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Range.html#method-i-begin">#begin</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Range.html#method-i-cover-3F">#cover?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Range.html#method-i-each">#each</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Range.html#method-i-end">#end</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Range.html#method-i-eql-3F">#eql?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Range.html#method-i-exclude_end-3F">#exclude_end?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Range.html#method-i-first">#first</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Range.html#method-i-hash">#hash</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Range.html#method-i-include-3F">#include?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Range.html#method-i-inspect">#inspect</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Range.html#method-i-last">#last</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Range.html#method-i-max">#max</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Range.html#method-i-member-3F">#member?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Range.html#method-i-min">#min</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Range.html#method-i-step">#step</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Range.html#method-i-to_s">#to_s</a></li>
             </ul>
         </div>
     </div>
@@ -1423,27 +1423,27 @@ title:     Ruby Cheat Sheet
         <h2 class="board-title">Rational</h2>
         <div class="board-card">
             <ul>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Rational.html#method-i-2A">#*</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Rational.html#method-i-2A-2A">#**</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Rational.html#method-i-2B">#+</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Rational.html#method-i-2D">#-</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Rational.html#method-i-2F">#/</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Rational.html#method-i-3C-3D-3E">#&lt;=&gt;</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Rational.html#method-i-3D-3D">#==</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Rational.html#method-i-ceil">#ceil</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Rational.html#method-i-denominator">#denominator</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Rational.html#method-i-fdiv">#fdiv</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Rational.html#method-i-floor">#floor</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Rational.html#method-i-inspect">#inspect</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Rational.html#method-i-numerator">#numerator</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Rational.html#method-i-quo">#quo</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Rational.html#method-i-rationalize">#rationalize</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Rational.html#method-i-round">#round</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Rational.html#method-i-to_f">#to_f</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Rational.html#method-i-to_i">#to_i</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Rational.html#method-i-to_r">#to_r</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Rational.html#method-i-to_s">#to_s</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Rational.html#method-i-truncate">#truncate</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Rational.html#method-i-2A">#*</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Rational.html#method-i-2A-2A">#**</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Rational.html#method-i-2B">#+</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Rational.html#method-i-2D">#-</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Rational.html#method-i-2F">#/</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Rational.html#method-i-3C-3D-3E">#&lt;=&gt;</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Rational.html#method-i-3D-3D">#==</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Rational.html#method-i-ceil">#ceil</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Rational.html#method-i-denominator">#denominator</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Rational.html#method-i-fdiv">#fdiv</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Rational.html#method-i-floor">#floor</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Rational.html#method-i-inspect">#inspect</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Rational.html#method-i-numerator">#numerator</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Rational.html#method-i-quo">#quo</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Rational.html#method-i-rationalize">#rationalize</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Rational.html#method-i-round">#round</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Rational.html#method-i-to_f">#to_f</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Rational.html#method-i-to_i">#to_i</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Rational.html#method-i-to_r">#to_r</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Rational.html#method-i-to_s">#to_s</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Rational.html#method-i-truncate">#truncate</a></li>
             </ul>
         </div>
     </div>
@@ -1452,31 +1452,31 @@ title:     Ruby Cheat Sheet
         <h2 class="board-title">Symbol</h2>
         <div class="board-card">
             <ul>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Symbol.html#method-c-all_symbols">::all_symbols</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Symbol.html#method-i-3C-3D-3E">#&lt;=&gt;</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Symbol.html#method-i-3D-3D">#==</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Symbol.html#method-i-3D-3D-3D">#===</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Symbol.html#method-i-3D-7E">#=~</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Symbol.html#method-i-5B-5D">#[]</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Symbol.html#method-i-capitalize">#capitalize</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Symbol.html#method-i-casecmp">#casecmp</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Symbol.html#method-i-downcase">#downcase</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Symbol.html#method-i-empty-3F">#empty?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Symbol.html#method-i-encoding">#encoding</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Symbol.html#method-i-id2name">#id2name</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Symbol.html#method-i-inspect">#inspect</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Symbol.html#method-i-intern">#intern</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Symbol.html#method-i-length">#length</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Symbol.html#method-i-match">#match</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Symbol.html#method-i-next">#next</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Symbol.html#method-i-size">#size</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Symbol.html#method-i-slice">#slice</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Symbol.html#method-i-succ">#succ</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Symbol.html#method-i-swapcase">#swapcase</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Symbol.html#method-i-to_proc">#to_proc</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Symbol.html#method-i-to_s">#to_s</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Symbol.html#method-i-to_sym">#to_sym</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Symbol.html#method-i-upcase">#upcase</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Symbol.html#method-c-all_symbols">::all_symbols</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Symbol.html#method-i-3C-3D-3E">#&lt;=&gt;</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Symbol.html#method-i-3D-3D">#==</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Symbol.html#method-i-3D-3D-3D">#===</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Symbol.html#method-i-3D-7E">#=~</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Symbol.html#method-i-5B-5D">#[]</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Symbol.html#method-i-capitalize">#capitalize</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Symbol.html#method-i-casecmp">#casecmp</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Symbol.html#method-i-downcase">#downcase</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Symbol.html#method-i-empty-3F">#empty?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Symbol.html#method-i-encoding">#encoding</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Symbol.html#method-i-id2name">#id2name</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Symbol.html#method-i-inspect">#inspect</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Symbol.html#method-i-intern">#intern</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Symbol.html#method-i-length">#length</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Symbol.html#method-i-match">#match</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Symbol.html#method-i-next">#next</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Symbol.html#method-i-size">#size</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Symbol.html#method-i-slice">#slice</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Symbol.html#method-i-succ">#succ</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Symbol.html#method-i-swapcase">#swapcase</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Symbol.html#method-i-to_proc">#to_proc</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Symbol.html#method-i-to_s">#to_s</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Symbol.html#method-i-to_sym">#to_sym</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Symbol.html#method-i-upcase">#upcase</a></li>
             </ul>
         </div>
     </div>
@@ -1485,45 +1485,45 @@ title:     Ruby Cheat Sheet
         <h2 class="board-title">Thread</h2>
         <div class="board-card">
             <ul>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-c-DEBUG">::DEBUG</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-c-DEBUG-3D">::DEBUG=</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-c-abort_on_exception">::abort_on_exception</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-c-abort_on_exception-3D">::abort_on_exception=</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-c-current">::current</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-c-exclusive">::exclusive</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-c-exit">::exit</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-c-fork">::fork</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-c-kill">::kill</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-c-list">::list</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-c-main">::main</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-c-pass">::pass</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-c-start">::start</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-c-stop">::stop</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-i-5B-5D">#[]</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-i-5B-5D-3D">#[]=</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-i-abort_on_exception">#abort_on_exception</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-i-abort_on_exception-3D">#abort_on_exception=</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-i-add_trace_func">#add_trace_func</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-i-alive-3F">#alive?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-i-backtrace">#backtrace</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-i-exit">#exit</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-i-group">#group</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-i-inspect">#inspect</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-i-join">#join</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-i-key-3F">#key?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-i-keys">#keys</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-i-kill">#kill</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-i-priority">#priority</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-i-priority-3D">#priority=</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-i-raise">#raise</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-i-run">#run</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-i-safe_level">#safe_level</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-i-set_trace_func">#set_trace_func</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-i-status">#status</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-i-stop-3F">#stop?</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-i-terminate">#terminate</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-i-value">#value</a></li>
-                <li><a href="http://www.ruby-doc.org/core-1.9.3/Thread.html#method-i-wakeup">#wakeup</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-c-DEBUG">::DEBUG</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-c-DEBUG-3D">::DEBUG=</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-c-abort_on_exception">::abort_on_exception</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-c-abort_on_exception-3D">::abort_on_exception=</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-c-current">::current</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-c-exclusive">::exclusive</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-c-exit">::exit</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-c-fork">::fork</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-c-kill">::kill</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-c-list">::list</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-c-main">::main</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-c-pass">::pass</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-c-start">::start</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-c-stop">::stop</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-i-5B-5D">#[]</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-i-5B-5D-3D">#[]=</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-i-abort_on_exception">#abort_on_exception</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-i-abort_on_exception-3D">#abort_on_exception=</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-i-add_trace_func">#add_trace_func</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-i-alive-3F">#alive?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-i-backtrace">#backtrace</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-i-exit">#exit</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-i-group">#group</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-i-inspect">#inspect</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-i-join">#join</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-i-key-3F">#key?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-i-keys">#keys</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-i-kill">#kill</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-i-priority">#priority</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-i-priority-3D">#priority=</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-i-raise">#raise</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-i-run">#run</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-i-safe_level">#safe_level</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-i-set_trace_func">#set_trace_func</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-i-status">#status</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-i-stop-3F">#stop?</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-i-terminate">#terminate</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-i-value">#value</a></li>
+                <li><a href="http://www.ruby-doc.org/core/Thread.html#method-i-wakeup">#wakeup</a></li>
             </ul>
         </div>
     </div>


### PR DESCRIPTION
## Background

update links to point to current version of Ruby

## Notes

By removing `core-1.9.3` in the links, and just pointing to `core`, when the page is visited, it automatically redirects to the method definition of the **current** version of the language (which at the time of this PR, the current up-to-date version of Ruby is 2.6)

This makes it so you don't have to worry about manually updating the version number in the link.

e.g. http://www.ruby-doc.org/core-1.9.3/Array.html#method-i-count -> http://www.ruby-doc.org/core/Array.html#method-i-count (will redirect and change link to `core-2.6`)